### PR TITLE
Add Classpert under the MOOcs list

### DIFF
--- a/2018/11/22/best-websites-a-programmer-should-visit/index.html
+++ b/2018/11/22/best-websites-a-programmer-should-visit/index.html
@@ -596,6 +596,7 @@
 </ul>
 <h2 id="MOOCs-for-learning-something-new"><a href="#MOOCs-for-learning-something-new" class="headerlink" title="MOOCs for learning something new"></a>MOOCs for learning something new</h2><ul>
 <li><a href="https://www.class-central.com" target="_blank" rel="external">Class Central</a> : a directory of 100,000+ student reviews of thousands of MOOCs.</li>
+<li><a href="https://classpert.com" target="_blank" rel="external">Classpert</a> : a search engine for MOOCs and online courses focusing on computer science and data science</li>
 <li><a href="https://docs.google.com/spreadsheets/d/1BD8BJJUNaX63m2QmySWMGDp71nx4W4MyyiIBlfMoN3Q/htmlview?sle=true#" target="_blank" rel="external">Computer Science Resources</a> : list of MOOCs for autodidacts</li>
 <li><a href="https://www.coursera.org" target="_blank" rel="external">Coursera.org</a> : Take the world’s best courses, online.</li>
 <li><a href="https://www.youtube.com/user/cs50tv/videos" target="_blank" rel="external">CS50</a> : A set of goods tutorials from cs50</li>


### PR DESCRIPTION
Recently, we launched https://classpert.com - a free search engine for online courses. Our main focus is on Computer Science and Data Science courses (we have indexed over 150k courses so far). I'm adding it under the MOOCs list, as I believe it might be a valuable resource for programmers.